### PR TITLE
Update chrome web store link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TypeLingo
-**Get the extension here: [Chrome Web Store](https://chrome.google.com/webstore/detail/typelingo/lkfdecookegdklhpafhikjebeflcgepc?snuoi)**
+**Get the extension here: [Chrome Web Store](https://chromewebstore.google.com/detail/typelingo/lkfdecookegdklhpafhikjebeflcgepc)**
 
 Duolingo typing restored! Get back the ability to type your responses.
 


### PR DESCRIPTION
chrome.google.com is moving to chromewebstore.google.com.  We can update the link now, hence the PR.